### PR TITLE
Исправить название схемы в README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ discord funny bot
 
 # Разворачивание бота
 
-1. в MySQL создаем схему с названием barsik `CREATE SCHEMA 'test' DEFAULT CHARACTER SET utf8 ;`, в случае если пользователь схемы отличается от root/root, актуальные данные следует внести в application.properties в значения spring.datasource.username=root
+1. в MySQL создаем схему с названием barsik `CREATE SCHEMA 'barsik' DEFAULT CHARACTER SET utf8 ;`, в случае если пользователь схемы отличается от root/root, актуальные данные следует внести в application.properties в значения spring.datasource.username=root
    spring.datasource.password=root
 2. Заполняем проперти в application.properties token значением актуального ключа бота. (В целях безопасности не стоит вносить этот ключ в комит)
 3. Можно выполнять сборку и запуск приложения.


### PR DESCRIPTION
## Что изменилось
- В инструкции по разворачиванию бота пример SQL-команды создавал схему 	est, хотя текст инструкции и pplication.properties (spring.datasource.url=jdbc:mysql://mysql:3306/barsik...) ссылаются на схему arsik.
- Поправлено имя схемы в примере команды на arsik, чтобы инструкция была самосогласованной и рабочей при копировании как есть.

## Как проверить
- Прочитать README.md: шаг 1 раздела Разворачивание бота теперь создаёт схему с тем же именем, что указано в тексте и используется в конфиге приложения.